### PR TITLE
fix: Avoid triggering too many effects when keeping keyboard key pressed

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+//registry.npmjs.org/:_authToken=${NPM_TOKEN_SPLASH_WEB}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-use-ripple",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "description": "A react hook to create material design ripples for components",
   "author": "cbadger85",
   "keywords": [

--- a/src/__tests__/index.test.tsx
+++ b/src/__tests__/index.test.tsx
@@ -136,6 +136,28 @@ describe('useRipple', () => {
     expect(ripple).toBeFalsy();
   });
 
+  it('should not show several ripples for a continuous enter press', () => {
+    const { container } = render(<TestComponent />);
+
+    fireEvent.keyDown(screen.getByText('Button'), { key: 'Enter' });
+    fireEvent.keyDown(screen.getByText('Button'), { key: 'Enter' });
+
+    const ripples = container.querySelectorAll('span');
+
+    expect(ripples.length).toBe(1);
+  });
+
+  it('should not show several ripples for a continuous spacebar press', () => {
+    const { container } = render(<TestComponent />);
+
+    fireEvent.keyDown(screen.getByText('Button'), { key: ' ' });
+    fireEvent.keyDown(screen.getByText('Button'), { key: ' ' });
+
+    const ripples = container.querySelectorAll('span');
+
+    expect(ripples.length).toBe(1);
+  });
+
   it('should remove the ripple and keyframe after the animation', async () => {
     const { container } = render(<TestComponent />);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -129,7 +129,15 @@ export const useRipple = (
     };
 
     element.addEventListener('mousedown', ripple);
-    element.addEventListener('keydown', keyboardRipple);
+
+    function keyboardListener(event: KeyboardEvent) {
+      document.removeEventListener("keydown", keyboardListener);
+      keyboardRipple(event);
+      setTimeout(function() {
+        document.addEventListener('keydown', keyboardListener);
+      }, options?.animationLength || ANIMATION_LENGTH);
+    }
+    document.addEventListener('keydown', keyboardListener);
 
     return () => {
       element.removeEventListener('mousedown', ripple);


### PR DESCRIPTION
# What are you trying to accomplish?

When an element is triggering the ripple effect with a continuous press to the SPACE or ENTER keys, a huge amount of effects happens. This commit ensures the animation ends before listening to new triggers.

This is the error in action (navigate with the keyboard to the button, and keep SPACE pressed):
![BeforeKeyboard](https://user-images.githubusercontent.com/2715429/227261951-b8dc9efb-f9ed-4e02-9fe9-c3a1cb63f683.gif)

And this is how it looks with the fix (navigate with the keyboard to the button, and keep SPACE pressed):
![AfterKeyboard](https://user-images.githubusercontent.com/2715429/227262269-f91f56a0-cd5c-4067-ad80-e54fd49609fe.gif)


# What is the approach followed?

When the `keydown` event happens, we remove the `keydown` listener for the time the animation will last. Once the mentioned time is reached, we add the listener again.