### PR TITLE
SWP-98156 Make ripple to be triggered base on if the event.target is the 'self' element where the event was attached

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -137,11 +137,11 @@ export const useRipple = (
 
     function keyboardListener(event: KeyboardEvent) {
       const targetElement = event?.target as HTMLElement;
-      const isThereARippleEffectRunning = !targetElement?.getElementsByClassName(
+      const theresNoRippleEffectRunning = !targetElement?.getElementsByClassName(
         RIPPLE_CLASSNAME,
       ).length;
 
-      if (isThereARippleEffectRunning) {
+      if (!theresNoRippleEffectRunning) {
         keyboardRipple(event);
       }
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -141,7 +141,7 @@ export const useRipple = (
         RIPPLE_CLASSNAME,
       ).length;
 
-      if (!theresNoRippleEffectRunning) {
+      if (theresNoRippleEffectRunning) {
         keyboardRipple(event);
       }
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -126,9 +126,9 @@ export const useRipple = (
     const ripple = createRipple(element, options);
 
     const keyboardRipple = (e: KeyboardEvent) => {
-      const isAnElegibleKey = [KEY_ENTER, KEY_SPACE].includes(e.key);
+      const isElegibleKey = [KEY_ENTER, KEY_SPACE].includes(e.key);
       const elementIsFocused = element === e.target;
-      const shouldRipple = isAnElegibleKey && elementIsFocused;
+      const shouldRipple = isElegibleKey && elementIsFocused;
 
       shouldRipple && ripple();
     };

--- a/src/index.ts
+++ b/src/index.ts
@@ -126,9 +126,9 @@ export const useRipple = (
     const ripple = createRipple(element, options);
 
     const keyboardRipple = (e: KeyboardEvent) => {
-      const isElegibleKey = [KEY_ENTER, KEY_SPACE].includes(e.key);
+      const isEligibleKey = [KEY_ENTER, KEY_SPACE].includes(e.key);
       const elementIsFocused = element === e.target;
-      const shouldRipple = isElegibleKey && elementIsFocused;
+      const shouldRipple = isEligibleKey && elementIsFocused;
 
       shouldRipple && ripple();
     };

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,9 @@ import { RefObject, useEffect } from 'react';
 const ANIMATION_LENGTH = 700;
 const RIPPLE_SIZE = 100;
 const RIPPLE_COLOR = 'rgba(0, 0, 0, 0.3)';
+const RIPPLE_CLASSNAME = 'ripple-effect';
+const KEY_ENTER = 'Enter';
+const KEY_SPACE = ' ';
 
 if (typeof document !== 'undefined') {
   const style = document.createElement('style');
@@ -79,7 +82,7 @@ const createRipple = (element: HTMLElement, options?: RippleOptions) => (
     : width / 2 - rippleSize / 2;
 
   const span = document.createElement('span');
-
+  span.className = RIPPLE_CLASSNAME;
   span.style.cssText = `
     top: ${positionTop}px;
     left: ${positionLeft}px;
@@ -123,22 +126,27 @@ export const useRipple = (
     const ripple = createRipple(element, options);
 
     const keyboardRipple = (e: KeyboardEvent) => {
-      if (e.key === 'Enter' || e.key === ' ') {
-        ripple();
-      }
+      const isAnElegibleKey = [KEY_ENTER, KEY_SPACE].includes(e.key);
+      const elementIsFocused = element === e.target;
+      const shouldRipple = isAnElegibleKey && elementIsFocused;
+
+      shouldRipple && ripple();
     };
 
     element.addEventListener('mousedown', ripple);
 
     function keyboardListener(event: KeyboardEvent) {
-      document.removeEventListener("keydown", keyboardListener);
-      keyboardRipple(event);
-      setTimeout(function() {
-        document.addEventListener('keydown', keyboardListener);
-      }, options?.animationLength || ANIMATION_LENGTH);
-    }
-    document.addEventListener('keydown', keyboardListener);
+      const targetElement = event?.target as HTMLElement;
+      const isThereARippleEffectRunning = !targetElement?.getElementsByClassName(
+        RIPPLE_CLASSNAME,
+      ).length;
 
+      if (isThereARippleEffectRunning) {
+        keyboardRipple(event);
+      }
+    }
+
+    document.addEventListener('keydown', keyboardListener);
     return () => {
       element.removeEventListener('mousedown', ripple);
       element.removeEventListener('keydown', keyboardRipple);


### PR DESCRIPTION
**What does this PR do?**
This PR is mainly doing 2 things:
- When a key event is happening we are checking if the event.target is the same as the element reference in which the hook instance is being executed.
- A full refactor on the debounce system so we avoid playing with event allocation and timeouts which are usually a bad pattern that lead to race conditions. Instead we will use the ripple element as our source of truth, if there's still a ripple in that element instance we can infer that the animation haven't finished and we shouldn't trigger a new ripple animation.

**What are the relevant tickets?**
https://splashthat.atlassian.net/browse/SWP-98156
